### PR TITLE
Implement Markdown readiness reporter for slice 03

### DIFF
--- a/modules/readiness/__init__.py
+++ b/modules/readiness/__init__.py
@@ -1,0 +1,9 @@
+"""Readiness reporting utilities for release snapshots."""
+
+from .reporter import aggregate_readiness, format_markdown, generate_readiness_report
+
+__all__ = [
+    "aggregate_readiness",
+    "format_markdown",
+    "generate_readiness_report",
+]

--- a/modules/readiness/reporter.py
+++ b/modules/readiness/reporter.py
@@ -1,0 +1,431 @@
+"""Aggregate snapshot delta signals into Markdown readiness reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from modules.utils import helpers
+from modules.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ChecklistItem:
+    """Structured representation of a remediation action."""
+
+    key: str
+    summary: str
+    status: str
+    category: str
+    notes: Tuple[str, ...]
+    category_rank: int
+    status_rank: int
+
+    def sort_key(self) -> Tuple[int, int, str, str]:
+        return (self.category_rank, self.status_rank, self.key, self.summary.lower())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "key": self.key,
+            "summary": self.summary,
+            "status": self.status,
+            "category": self.category,
+            "notes": list(self.notes),
+            "priority": {
+                "category": self.category_rank,
+                "status": self.status_rank,
+            },
+        }
+
+
+def _normalize_status(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        name = value.get("name")
+        if name:
+            return str(name)
+        return str(value)
+    return str(value)
+
+
+def _status_priority(status: Optional[str]) -> int:
+    if not status:
+        return 5
+    lowered = status.lower()
+    if "block" in lowered or "critical" in lowered:
+        return 0
+    if "high" in lowered or "urgent" in lowered:
+        return 1
+    if "progress" in lowered:
+        return 2
+    if "review" in lowered or "qa" in lowered:
+        return 3
+    if "ready" in lowered or "done" in lowered:
+        return 4
+    return 5
+
+
+CATEGORY_PRIORITY = {
+    "New Issue": 0,
+    "Changed Issue": 1,
+    "Open Issue": 2,
+}
+
+
+def _category_priority(category: str) -> int:
+    return CATEGORY_PRIORITY.get(category, 9)
+
+
+def _issue_identifier(issue: Mapping[str, Any], default_prefix: str = "issue") -> str:
+    key = issue.get("key")
+    if key:
+        return str(key)
+    summary = issue.get("summary")
+    if summary:
+        return f"{default_prefix}-{abs(hash(summary))}"[:32]
+    return f"{default_prefix}-unknown"
+
+
+def _dedupe_notes(notes: Iterable[str]) -> Tuple[str, ...]:
+    seen: List[str] = []
+    for note in notes:
+        if note not in seen:
+            seen.append(note)
+    return tuple(seen)
+
+
+def _collect_checklist_items(
+    details: Mapping[str, Any],
+    done_statuses: Sequence[str],
+) -> List[ChecklistItem]:
+    done_lower = {str(status).lower() for status in done_statuses}
+    collected: MutableMapping[str, ChecklistItem] = {}
+
+    def _should_track(status: Optional[str]) -> bool:
+        return not status or status.lower() not in done_lower
+
+    def _store(
+        issue: Mapping[str, Any],
+        *,
+        category: str,
+        status: Optional[str],
+        base_notes: Sequence[str] = (),
+    ) -> None:
+        if not _should_track(status):
+            return
+        identifier = _issue_identifier(issue)
+        summary = issue.get("summary") or "Summary unavailable"
+        normalized_status = status or "Unknown"
+        category_rank = _category_priority(category)
+        status_rank = _status_priority(status)
+        note_payload = tuple(base_notes)
+
+        existing = collected.get(identifier)
+        if existing:
+            merged_notes = _dedupe_notes(existing.notes + note_payload)
+            existing_category_rank = _category_priority(existing.category)
+            if category_rank < existing_category_rank:
+                best_category = category
+                best_category_rank = category_rank
+            else:
+                best_category = existing.category
+                best_category_rank = existing_category_rank
+            best_status_rank = min(existing.status_rank, status_rank)
+            status_text = (
+                normalized_status
+                if normalized_status != "Unknown"
+                else existing.status
+            )
+            collected[identifier] = ChecklistItem(
+                key=identifier,
+                summary=str(summary) if summary else existing.summary,
+                status=status_text,
+                category=best_category,
+                notes=merged_notes,
+                category_rank=best_category_rank,
+                status_rank=best_status_rank,
+            )
+            return
+
+        collected[identifier] = ChecklistItem(
+            key=identifier,
+            summary=str(summary),
+            status=normalized_status,
+            category=category,
+            notes=note_payload,
+            category_rank=category_rank,
+            status_rank=status_rank,
+        )
+
+    added = details.get("added") or []
+    for issue in added:
+        status = _normalize_status(issue.get("status"))
+        _store(
+            issue,
+            category="New Issue",
+            status=status,
+            base_notes=("Newly captured in latest snapshot.",),
+        )
+
+    changed = details.get("changed") or []
+    for issue in changed:
+        changes = issue.get("changes", {})
+        status_change = changes.get("status")
+        status = _normalize_status((status_change or {}).get("current") or issue.get("status"))
+        notes: List[str] = []
+        for field, payload in sorted(changes.items()):
+            previous = payload.get("previous")
+            current = payload.get("current")
+            notes.append(f"{field}: {previous} ➜ {current}")
+        if not notes:
+            notes.append("Field updates detected without detailed payload.")
+        _store(
+            issue,
+            category="Changed Issue",
+            status=status,
+            base_notes=tuple(notes),
+        )
+
+    unchanged = details.get("unchanged") or []
+    for issue in unchanged:
+        status = _normalize_status(issue.get("status"))
+        _store(
+            issue,
+            category="Open Issue",
+            status=status,
+            base_notes=("Status unchanged since previous snapshot.",),
+        )
+
+    return sorted(collected.values(), key=lambda item: item.sort_key())
+
+
+def _extract_summary(delta: Mapping[str, Any]) -> Dict[str, Any]:
+    summary = delta.get("summary")
+    if isinstance(summary, Mapping):
+        return dict(summary)
+    counts = delta.get("counts")
+    if isinstance(counts, Mapping):
+        return {
+            "total_current": counts.get("total", sum(counts.values())) if "total" in counts else None,
+            "field_deltas": delta.get("field_deltas") or {},
+            "counts": dict(counts),
+        }
+    return {}
+
+
+def _extract_details(delta: Mapping[str, Any]) -> Dict[str, Any]:
+    details = delta.get("details")
+    if isinstance(details, Mapping):
+        return dict(details)
+    return {}
+
+
+def _derive_totals(summary: Mapping[str, Any]) -> Dict[str, int]:
+    totals: Dict[str, int] = {}
+    for key, value in summary.items():
+        if isinstance(value, int):
+            totals[key] = value
+    counts = summary.get("counts")
+    if isinstance(counts, Mapping):
+        for key, value in counts.items():
+            if isinstance(value, int):
+                totals.setdefault(key, value)
+    return totals
+
+
+def _compute_readiness_score(open_items: int, total_issues: int) -> Tuple[int, str]:
+    if total_issues <= 0:
+        return 100, "On Track"
+    completion_ratio = max(0.0, 1.0 - (open_items / max(total_issues, 1)))
+    score = int(round(completion_ratio * 100))
+    if score >= 85:
+        label = "On Track"
+    elif score >= 60:
+        label = "Watch"
+    else:
+        label = "At Risk"
+    return score, label
+
+
+def aggregate_readiness(
+    delta: Mapping[str, Any],
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Aggregate analyzer signals into readiness metadata."""
+
+    config_data = dict(config) if config is not None else helpers.load_config()
+    project_config = config_data.get("project", {})
+    done_statuses = project_config.get("done_statuses", ["Done"])
+    reporting_config = config_data.get("reporting", {})
+    timezone = reporting_config.get("timezone")
+
+    summary = _extract_summary(delta)
+    details = _extract_details(delta)
+
+    totals = _derive_totals(summary)
+    total_current = totals.get("total_current")
+    if total_current is None:
+        total_current = (
+            len(details.get("added", []))
+            + len(details.get("unchanged", []))
+            + len(details.get("changed", []))
+        )
+    checklist_items = _collect_checklist_items(details, done_statuses)
+    open_items = len(checklist_items)
+    score, score_label = _compute_readiness_score(open_items, total_current)
+
+    metadata = delta.get("metadata") or {}
+    fix_version = metadata.get("current_fix_version") or metadata.get("previous_fix_version")
+    if not fix_version:
+        fix_version = delta.get("fixVersion")
+
+    aggregated = {
+        "metadata": {
+            "fix_version": fix_version,
+            "current_snapshot": metadata.get("current_snapshot") or delta.get("current_snapshot"),
+            "previous_snapshot": metadata.get("previous_snapshot") or delta.get("previous_snapshot"),
+            "generated_at": helpers.current_timestamp(timezone).isoformat(),
+            "timezone": timezone,
+        },
+        "summary": {
+            "totals": totals,
+            "field_changes": summary.get("field_deltas") or summary.get("field_changes") or {},
+        },
+        "readiness": {
+            "score": score,
+            "label": score_label,
+            "open_items": open_items,
+            "total_issues": total_current,
+        },
+        "checklist": [item.to_dict() for item in checklist_items],
+    }
+
+    removed = details.get("removed") or []
+    aggregated["summary"]["removed"] = len(removed)
+    aggregated["summary"]["added"] = len(details.get("added") or [])
+    aggregated["summary"]["changed"] = len(details.get("changed") or [])
+
+    return aggregated
+
+
+def format_markdown(aggregated: Mapping[str, Any]) -> str:
+    """Format aggregated readiness data into Markdown."""
+
+    metadata = aggregated.get("metadata", {})
+    readiness = aggregated.get("readiness", {})
+    summary = aggregated.get("summary", {})
+    checklist = aggregated.get("checklist", [])
+
+    fix_version = metadata.get("fix_version") or "Unspecified Fix Version"
+    header = f"# Release Readiness – {fix_version}"
+    score = readiness.get("score", 0)
+    label = readiness.get("label", "Unknown")
+
+    lines = [header, ""]
+    lines.append("## Snapshot Details")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Current Snapshot | `{metadata.get('current_snapshot') or 'n/a'}` |")
+    lines.append(f"| Previous Snapshot | `{metadata.get('previous_snapshot') or 'n/a'}` |")
+    lines.append(f"| Generated At | {metadata.get('generated_at', 'Unknown')} |")
+    lines.append(f"| Readiness Score | {score}/100 ({label}) |")
+    lines.append("")
+
+    totals = summary.get("totals", {})
+    if totals:
+        lines.append("## Summary Metrics")
+        lines.append("")
+        for key, value in sorted(totals.items()):
+            lines.append(f"- **{key.replace('_', ' ').title()}:** {value}")
+        lines.append("")
+
+    field_changes = summary.get("field_changes") or {}
+    if field_changes:
+        lines.append("## Field Change Highlights")
+        lines.append("")
+        for field, count in field_changes.items():
+            lines.append(f"- `{field}` updated {count} time(s)")
+        lines.append("")
+
+    lines.append("## Prioritized Remediation Checklist")
+    lines.append("")
+    if not checklist:
+        lines.append("All tracked items are complete. No remediation required.")
+    else:
+        for item in checklist:
+            status = item.get("status", "Unknown")
+            category = item.get("category", "Open Issue")
+            summary_text = item.get("summary", "Summary unavailable")
+            lines.append(
+                f"- [ ] `{item.get('key')}` – {summary_text} _(Status: {status}; {category})_"
+            )
+            for note in item.get("notes", []):
+                lines.append(f"  - {note}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_readiness_report(
+    delta: Mapping[str, Any] | Path | str,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    persist: bool = True,
+) -> Dict[str, Any]:
+    """Create aggregated readiness data and Markdown report.
+
+    Parameters
+    ----------
+    delta:
+        Either a dictionary produced by the snapshot delta analyzer or a path to the
+        JSON payload on disk.
+    config:
+        Optional configuration dictionary. When omitted the global config file is
+        loaded.
+    persist:
+        When ``True`` the aggregated analysis and Markdown report are written to the
+        artifact directory as defined by ``ARTIFACT_ROOT``.
+    """
+
+    if isinstance(delta, (str, Path)):
+        payload = helpers.read_json(delta)
+    else:
+        payload = dict(delta)
+
+    config_data = dict(config) if config is not None else helpers.load_config()
+    aggregated = aggregate_readiness(payload, config=config_data)
+    markdown = format_markdown(aggregated)
+
+    analysis_path: Optional[Path] = None
+    report_path: Optional[Path] = None
+
+    if persist:
+        tz = config_data.get("reporting", {}).get("timezone")
+        timestamp = helpers.timestamp_for_filename(tz)
+
+        analysis_dir = helpers.artifact_path("03", "analysis")
+        report_dir = helpers.artifact_path("03", "reports")
+        helpers.ensure_directory(analysis_dir)
+        helpers.ensure_directory(report_dir)
+
+        analysis_path = analysis_dir / f"readiness_inputs_{timestamp}.json"
+        report_path = report_dir / f"readiness_summary_{timestamp}.md"
+
+        helpers.write_json_safe(aggregated, analysis_path)
+        report_path.write_text(markdown, encoding="utf-8")
+
+        LOGGER.info("Readiness analysis saved to %s", analysis_path)
+        LOGGER.info("Readiness summary saved to %s", report_path)
+
+    return {
+        "aggregated": aggregated,
+        "markdown": markdown,
+        "analysis_path": analysis_path,
+        "report_path": report_path,
+    }

--- a/reports/slice_03/readiness_template.md
+++ b/reports/slice_03/readiness_template.md
@@ -1,0 +1,56 @@
+# Slice 03 – Readiness Reporter Template
+
+This template documents the Markdown structure produced by
+`modules.readiness.reporter.generate_readiness_report`. It illustrates how the
+release readiness data is surfaced for stakeholders and highlights the
+placeholders that may be customized when integrating with other tooling.
+
+## Layout Overview
+
+1. **Title** – `# Release Readiness – <fix version>`
+2. **Snapshot Details** – Markdown table summarizing snapshot sources, the
+   generation timestamp, and computed readiness score.
+3. **Summary Metrics** – Bullet list of totals derived from the delta analyzer.
+4. **Field Change Highlights** – Optional section that lists fields updated across
+   issues along with how many times they changed between snapshots.
+5. **Prioritized Remediation Checklist** – Checkbox list of issues requiring
+   attention, sorted by category (new, changed, open) and severity keywords in the
+   issue status. Each item may contain nested bullets describing the underlying
+   field changes or rationale for inclusion.
+
+## Placeholder Reference
+
+| Placeholder | Description |
+| --- | --- |
+| `<fix version>` | Value from `metadata.current_fix_version` or `delta.fixVersion`. |
+| `<current snapshot>` | File name of the most recent snapshot analyzed. |
+| `<previous snapshot>` | File name of the baseline snapshot (may be `n/a`). |
+| `<generated at>` | ISO 8601 timestamp respecting the configured timezone. |
+| `<score>` | Computed readiness score scaled from 0–100. |
+| `<field>` | Field name encountered in delta field changes. |
+| `<count>` | Number of times the field changed between snapshots. |
+| `<issue key>` | Jira issue key displayed in checklist entries. |
+| `<status>` | Normalized status pulled from analyzer outputs. |
+| `<category>` | Indicates whether the item is new, changed, or unchanged. |
+| `<notes>` | Additional bullet points for context (status change, new issue, etc.). |
+
+## Distribution Guidance
+
+- Save generated reports under `${ARTIFACT_ROOT}/03/reports/` using the
+  filename convention `readiness_summary_<timestamp>.md`.
+- Pair each Markdown report with an analysis JSON artifact stored at
+  `${ARTIFACT_ROOT}/03/analysis/readiness_inputs_<timestamp>.json` for traceability.
+- Share the Markdown report with engineering leads and release managers ahead of
+  go/no-go checkpoints. The checklist section is intended to guide remediation
+  discussions and should be reviewed during readiness stand-ups.
+
+## Customization Notes
+
+- The reporter defaults to config-defined `project.done_statuses` to determine
+  which statuses are considered complete. Update `configs/config.yaml` if your
+  workflow uses different terminology.
+- Additional templating (for example, company-branded headers) can be layered on
+  by wrapping the Markdown output in a broader documentation generator.
+- The checklist intentionally omits issues in done states to focus readers on
+  remaining work. Adjust `_collect_checklist_items` if your rollout requires a
+  different emphasis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ deepdiff>=6.7.1
 PyYAML>=6.0.1
 Jinja2>=3.1.2
 python-dotenv>=1.0.0
+pytest>=7.4.0

--- a/tests/test_readiness_reporter.py
+++ b/tests/test_readiness_reporter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from modules.readiness import reporter
+
+
+@pytest.fixture
+def sample_delta() -> dict[str, object]:
+    return {
+        "metadata": {
+            "current_snapshot": "snapshot_20240608.json",
+            "previous_snapshot": "snapshot_20240601.json",
+            "current_fix_version": "2024.06",
+        },
+        "summary": {
+            "total_current": 4,
+            "added": 1,
+            "removed": 0,
+            "changed": 1,
+            "unchanged": 2,
+            "field_deltas": {"status": 2, "deployment_notes": 1},
+        },
+        "details": {
+            "added": [
+                {
+                    "key": "ABC-1",
+                    "summary": "New login flow instrumentation",
+                    "status": "In Progress",
+                }
+            ],
+            "removed": [],
+            "changed": [
+                {
+                    "key": "ABC-2",
+                    "summary": "Audit logging hardening",
+                    "changes": {
+                        "status": {"previous": "In Progress", "current": "Blocked"},
+                        "deployment_notes": {
+                            "previous": "Pending security",
+                            "current": "Security review requested",
+                        },
+                    },
+                }
+            ],
+            "unchanged": [
+                {
+                    "key": "ABC-3",
+                    "summary": "Feature flag cleanup",
+                    "status": "Ready for Prod",
+                },
+                {
+                    "key": "ABC-4",
+                    "summary": "QA automation",
+                    "status": "In Review",
+                },
+            ],
+        },
+    }
+
+
+def test_aggregate_readiness_scores_open_items(sample_delta: dict[str, object]) -> None:
+    aggregated = reporter.aggregate_readiness(sample_delta)
+
+    readiness = aggregated["readiness"]
+    assert readiness["open_items"] == 3
+    assert readiness["total_issues"] == 4
+    assert readiness["score"] == 25
+    assert readiness["label"] == "At Risk"
+
+    checklist = aggregated["checklist"]
+    assert any(item["key"] == "ABC-1" for item in checklist)
+    assert any("status: In Progress ➜ Blocked" in note for item in checklist for note in item["notes"])
+
+
+def test_format_markdown_contains_sections(sample_delta: dict[str, object]) -> None:
+    aggregated = reporter.aggregate_readiness(sample_delta)
+    markdown = reporter.format_markdown(aggregated)
+
+    assert "# Release Readiness" in markdown
+    assert "## Snapshot Details" in markdown
+    assert "Prioritized Remediation Checklist" in markdown
+    assert "`ABC-1`" in markdown
+
+
+def test_generate_readiness_report_persists_artifacts(tmp_path: Path, sample_delta: dict[str, object]) -> None:
+    os.environ["ARTIFACT_ROOT"] = str(tmp_path)
+
+    result = reporter.generate_readiness_report(sample_delta, persist=True)
+
+    analysis_path = result["analysis_path"]
+    report_path = result["report_path"]
+
+    assert analysis_path is not None and analysis_path.exists()
+    assert report_path is not None and report_path.exists()
+
+    analysis_data = analysis_path.read_text(encoding="utf-8")
+    report_data = report_path.read_text(encoding="utf-8")
+
+    assert "open_items" in analysis_data
+    assert "Release Readiness" in report_data
+
+    # Clean up environment override
+    del os.environ["ARTIFACT_ROOT"]


### PR DESCRIPTION
## Summary
- add a readiness reporter module that aggregates analyzer signals into checklist-driven Markdown and persists artifacts for slice 03
- document the slice 03 report template layout and placeholders
- cover the readiness reporter with unit tests and add pytest as a dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690cf27847a4832fb3d41ca5e5a5e360