### PR TITLE
Slice 04 – Config and Logging Framework

### DIFF
--- a/modules/config/__init__.py
+++ b/modules/config/__init__.py
@@ -1,0 +1,9 @@
+"""Configuration utilities for Release Intelligence."""
+
+from .loader import ConfigLoader, ConfigValidationError, load_config
+
+__all__ = [
+    "ConfigLoader",
+    "ConfigValidationError",
+    "load_config",
+]

--- a/modules/config/loader.py
+++ b/modules/config/loader.py
@@ -1,0 +1,191 @@
+"""Centralized configuration loader with environment overrides and validation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency fallback
+    load_dotenv = None  # type: ignore[assignment]
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - optional dependency fallback
+    import json as _json
+
+    class _SimpleYAML:  # type: ignore[misc]
+        """Minimal YAML parser fallback that supports JSON-formatted content."""
+
+        @staticmethod
+        def safe_load(stream):  # type: ignore[override]
+            if hasattr(stream, "read"):
+                return _json.loads(stream.read())
+            return _json.loads(stream)
+
+    yaml = _SimpleYAML()
+
+
+DEFAULTS: Mapping[str, Any] = {
+    "jira": {
+        "base_url": "",
+        "auth_url": "",
+        "token_url": "",
+        "api_scope": "read:jira-work offline_access",
+        "token_path": "~/.jira_token.json",
+        "redirect_uri": "http://localhost:8080/callback",
+        "jql_fields": ["key", "summary", "status"],
+    },
+    "project": {
+        "done_statuses": ["Done"],
+        "deployment_notes_field": "",
+    },
+    "paths": {
+        "snapshot_dir": "snapshots",
+        "logs_dir": "logs",
+        "reports_dir": "reports",
+        "prompts_dir": "prompts",
+    },
+    "reporting": {
+        "timezone": "UTC",
+        "report_template": "default",
+    },
+}
+
+ENVIRONMENT_OVERRIDES: Mapping[tuple[str, str], str] = {
+    ("jira", "base_url"): "JIRA_BASE_URL",
+    ("jira", "auth_url"): "JIRA_AUTH_URL",
+    ("jira", "token_url"): "JIRA_TOKEN_URL",
+    ("jira", "api_scope"): "JIRA_API_SCOPE",
+    ("jira", "token_path"): "JIRA_TOKEN_PATH",
+    ("jira", "redirect_uri"): "JIRA_REDIRECT_URI",
+    ("paths", "snapshot_dir"): "SNAPSHOT_DIR",
+    ("paths", "logs_dir"): "LOGS_DIR",
+    ("paths", "reports_dir"): "REPORTS_DIR",
+    ("paths", "prompts_dir"): "PROMPTS_DIR",
+    ("reporting", "timezone"): "REPORTING_TIMEZONE",
+}
+
+REQUIRED_FIELDS: Mapping[str, Iterable[str]] = {
+    "jira": ("base_url", "auth_url", "token_url", "api_scope"),
+    "paths": ("snapshot_dir", "logs_dir", "reports_dir"),
+}
+
+
+class ConfigValidationError(ValueError):
+    """Raised when the configuration fails validation."""
+
+    def __init__(self, errors: Iterable[str]):
+        self.errors = list(errors)
+        message = "; ".join(self.errors) if self.errors else "Invalid configuration"
+        super().__init__(message)
+
+
+@dataclass(slots=True)
+class ConfigLoader:
+    """Load configuration files with environment overrides and schema validation."""
+
+    config_path: Optional[Path | str] = None
+    dotenv_path: Optional[Path | str] = None
+    defaults: Mapping[str, Any] = field(default_factory=lambda: DEFAULTS)
+
+    def load(self) -> Dict[str, Any]:
+        """Return the merged configuration dictionary."""
+
+        self._load_dotenv()
+        config = self._read_config()
+        merged = self._apply_defaults(config)
+        merged = self._apply_environment_overrides(merged)
+        self._validate(merged)
+        return merged
+
+    # -- internal helpers -------------------------------------------------
+    def _load_dotenv(self) -> None:
+        path = Path(self.dotenv_path).expanduser() if self.dotenv_path else self._project_root() / ".env"
+        if path.exists():
+            if load_dotenv is not None:
+                load_dotenv(dotenv_path=path)  # type: ignore[arg-type]
+                return
+
+            for line in path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#") or "=" not in stripped:
+                    continue
+                key, _, value = stripped.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+
+    def _read_config(self) -> Dict[str, Any]:
+        config_file = Path(self.config_path).expanduser() if self.config_path else self._default_config_path()
+        if not config_file.exists():
+            return {}
+
+        with config_file.open("r", encoding="utf-8") as stream:
+            loaded = yaml.safe_load(stream) or {}
+        if not isinstance(loaded, MutableMapping):
+            raise ConfigValidationError(["Configuration file must contain a mapping at the top level."])
+        return dict(loaded)
+
+    def _apply_defaults(self, config: Mapping[str, Any]) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {section: dict(values) for section, values in self.defaults.items()}
+        for section, values in config.items():
+            if isinstance(values, Mapping):
+                merged.setdefault(section, {})
+                merged[section].update(values)
+            else:
+                merged[section] = values
+        return merged
+
+    def _apply_environment_overrides(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        for (section, key), env_var in ENVIRONMENT_OVERRIDES.items():
+            value = os.getenv(env_var)
+            if value:
+                section_values = config.setdefault(section, {})
+                if isinstance(section_values, Mapping):
+                    section_values[key] = value
+                else:
+                    config[section] = {key: value}
+        return config
+
+    def _validate(self, config: Mapping[str, Any]) -> None:
+        errors: list[str] = []
+        for section, keys in REQUIRED_FIELDS.items():
+            section_values = config.get(section, {})
+            if not isinstance(section_values, Mapping):
+                errors.append(f"Section '{section}' must be a mapping")
+                continue
+            for key in keys:
+                value = section_values.get(key)
+                if value in (None, ""):
+                    errors.append(f"Missing required setting '{section}.{key}'")
+        # Basic structure validation for list fields
+        jira_fields = config.get("jira", {}).get("jql_fields")
+        if jira_fields is not None and not isinstance(jira_fields, list):
+            errors.append("jira.jql_fields must be a list when provided")
+
+        done_statuses = config.get("project", {}).get("done_statuses")
+        if done_statuses is not None and not isinstance(done_statuses, list):
+            errors.append("project.done_statuses must be a list when provided")
+
+        if errors:
+            raise ConfigValidationError(errors)
+
+    def _default_config_path(self) -> Path:
+        return self._project_root() / "configs" / "config.yaml"
+
+    @staticmethod
+    def _project_root() -> Path:
+        return Path(__file__).resolve().parents[2]
+
+
+def load_config(
+    override_path: Optional[Path | str] = None,
+    dotenv_path: Optional[Path | str] = None,
+    defaults: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Convenience wrapper returning the loaded configuration."""
+
+    loader = ConfigLoader(config_path=override_path, dotenv_path=dotenv_path, defaults=defaults or DEFAULTS)
+    return loader.load()

--- a/modules/logging/__init__.py
+++ b/modules/logging/__init__.py
@@ -1,0 +1,5 @@
+"""Logging utilities for Release Intelligence."""
+
+from .factory import LoggerFactory, get_logger
+
+__all__ = ["LoggerFactory", "get_logger"]

--- a/modules/logging/factory.py
+++ b/modules/logging/factory.py
@@ -1,0 +1,186 @@
+"""JSON logging factory supporting slice metadata and masking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from modules.utils.helpers import artifact_root, ensure_directory
+
+_STANDARD_LOG_ATTRIBUTES: set[str] = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "message",
+    "stack",
+}
+
+
+class _JsonFormatter(logging.Formatter):
+    """Format log records as JSON with masked sensitive values."""
+
+    def __init__(
+        self,
+        *,
+        slice_id: Optional[str] = None,
+        phase: Optional[str] = None,
+        masked_values: Optional[Iterable[str]] = None,
+    ) -> None:
+        super().__init__()
+        self.slice_id = slice_id or os.getenv("ACTIVE_SLICE_ID", "unknown")
+        self.phase = phase or os.getenv("MOP_PHASE", "unknown")
+        self.masked_values = [value for value in (masked_values or []) if value]
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - interface method
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "slice_id": getattr(record, "slice_id", self.slice_id),
+            "phase": getattr(record, "phase", self.phase),
+        }
+
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOG_ATTRIBUTES or key in payload or key.startswith("_"):
+                continue
+            payload[key] = value
+
+        masked = self._mask(payload)
+        return json.dumps(masked, ensure_ascii=False)
+
+    # -- internal helpers -------------------------------------------------
+    def _mask(self, value: Any) -> Any:
+        if isinstance(value, str):
+            masked_value = value
+            for secret in self.masked_values:
+                if secret and secret in masked_value:
+                    masked_value = masked_value.replace(secret, "***")
+            return masked_value
+        if isinstance(value, Mapping):
+            return {key: self._mask(sub_value) for key, sub_value in value.items()}
+        if isinstance(value, list):
+            return [self._mask(item) for item in value]
+        return value
+
+
+@dataclass(slots=True)
+class LoggerFactory:
+    """Factory for creating JSON-formatted loggers."""
+
+    slice_id: Optional[str] = None
+    phase: Optional[str] = None
+    masked_values: Iterable[str] = field(default_factory=list)
+    _masked_values: list[str] = field(init=False, repr=False)
+    _loggers: Dict[str, logging.Logger] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        secrets = [os.getenv("JIRA_SECRET"), os.getenv("SSL_CERT_PATH")]
+        self._masked_values = [value for value in [*self.masked_values, *secrets] if value]
+        self._loggers = {}
+
+    def get_logger(
+        self,
+        name: str,
+        *,
+        log_file: Optional[Path | str] = None,
+        level: int = logging.INFO,
+    ) -> logging.Logger:
+        """Return a configured JSON logger with optional file output."""
+
+        if name in self._loggers:
+            logger = self._loggers[name]
+            if log_file:
+                self._attach_file_handler(logger, log_file)
+            return logger
+
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+        logger.propagate = False
+        formatter = self._formatter()
+
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+
+        if log_file:
+            self._attach_file_handler(logger, log_file, formatter=formatter)
+
+        self._loggers[name] = logger
+        return logger
+
+    # -- internal helpers -------------------------------------------------
+    def _formatter(self) -> _JsonFormatter:
+        return _JsonFormatter(
+            slice_id=self.slice_id,
+            phase=self.phase,
+            masked_values=self._masked_values,
+        )
+
+    def _attach_file_handler(
+        self,
+        logger: logging.Logger,
+        log_file: Path | str,
+        formatter: Optional[_JsonFormatter] = None,
+    ) -> None:
+        path = self._resolve_log_path(log_file)
+        for handler in logger.handlers:
+            if isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == path:
+                return
+
+        file_handler = logging.FileHandler(path, encoding="utf-8")
+        file_handler.setFormatter(formatter or self._formatter())
+        logger.addHandler(file_handler)
+
+    def _resolve_log_path(self, log_file: Path | str) -> Path:
+        path = Path(log_file)
+        if not path.is_absolute():
+            base = os.getenv("ARTIFACT_ROOT")
+            if base:
+                base_path = Path(base).expanduser().resolve()
+                ensure_directory(base_path)
+            else:
+                base_path = artifact_root()
+            path = base_path / path
+        ensure_directory(path.parent)
+        return path
+
+
+_default_factory: Optional[LoggerFactory] = None
+
+
+def get_logger(
+    name: str,
+    *,
+    log_file: Optional[Path | str] = None,
+    level: int = logging.INFO,
+) -> logging.Logger:
+    """Return a JSON logger from the default factory."""
+
+    global _default_factory
+    if _default_factory is None:
+        _default_factory = LoggerFactory()
+    return _default_factory.get_logger(name, log_file=log_file, level=level)

--- a/modules/utils/helpers.py
+++ b/modules/utils/helpers.py
@@ -8,27 +8,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-try:
-    from dotenv import load_dotenv
-except ImportError:  # pragma: no cover - optional dependency fallback
-    load_dotenv = None  # type: ignore[assignment]
-
-try:
-    import yaml
-except ImportError:
-    import json as _json
-
-    class _SimpleYAML:  # type: ignore[misc]
-        """Minimal YAML parser fallback that supports JSON-formatted content."""
-
-        @staticmethod
-        def safe_load(stream):  # type: ignore[override]
-            if hasattr(stream, "read"):
-                return _json.loads(stream.read())
-            return _json.loads(stream)
-
-    yaml = _SimpleYAML()
-
 
 def project_root() -> Path:
     """Return the root directory for the release snapshot manager project."""
@@ -43,21 +22,6 @@ def module_root() -> Path:
 def config_path() -> Path:
     """Return the default configuration file path."""
     return project_root() / "configs" / "config.yaml"
-
-
-def load_environment(dotenv_path: Optional[Path | str] = None) -> None:
-    """Load environment variables from a .env file when available."""
-
-    if load_dotenv is None:
-        return
-
-    resolved = (
-        Path(dotenv_path).expanduser()
-        if dotenv_path
-        else project_root() / ".env"
-    )
-    if resolved.exists():
-        load_dotenv(dotenv_path=resolved)  # type: ignore[arg-type]
 
 
 def artifact_root() -> Path:
@@ -91,42 +55,11 @@ def ssl_verify_path() -> Optional[Path]:
 
 
 def load_config(override_path: Optional[Path | str] = None) -> Dict[str, Any]:
-    """Load YAML configuration and override with environment variables when present."""
-    load_environment()
-    config_file = Path(override_path) if override_path else config_path()
-    if not config_file.exists():
-        raise FileNotFoundError(
-            f"Configuration file not found at {config_file}"
-        )
+    """Load configuration using the centralized loader module."""
 
-    with config_file.open("r", encoding="utf-8") as stream:
-        config = yaml.safe_load(stream) or {}
+    from modules.config.loader import load_config as _load_config
 
-    overrides = {
-        "jira": {
-            "base_url": os.getenv("JIRA_BASE_URL"),
-            "auth_url": os.getenv("JIRA_AUTH_URL"),
-            "token_url": os.getenv("JIRA_TOKEN_URL"),
-            "api_scope": os.getenv("JIRA_API_SCOPE"),
-            "token_path": os.getenv("JIRA_TOKEN_PATH"),
-            "redirect_uri": os.getenv("JIRA_REDIRECT_URI"),
-        },
-        "paths": {
-            "snapshot_dir": os.getenv("SNAPSHOT_DIR"),
-            "logs_dir": os.getenv("LOGS_DIR"),
-            "reports_dir": os.getenv("REPORTS_DIR"),
-            "prompts_dir": os.getenv("PROMPTS_DIR"),
-        },
-    }
-
-    for section, values in overrides.items():
-        if section not in config:
-            config[section] = {}
-        for key, value in values.items():
-            if value:
-                config[section][key] = value
-
-    return config
+    return _load_config(override_path)
 
 
 def ensure_directory(path: Path | str) -> Path:

--- a/modules/utils/logger.py
+++ b/modules/utils/logger.py
@@ -1,67 +1,24 @@
-"""Logging utilities for the Release Snapshot Manager."""
+"""Compatibility layer exposing JSON logging via :mod:`modules.logging`."""
 
 from __future__ import annotations
 
 import logging
-import os
-import sys
 from pathlib import Path
 from typing import Optional
 
-from .helpers import ensure_directory
+from modules.logging import LoggerFactory
+
+__all__ = ["LoggerFactory", "get_logger"]
 
 
-_LOGGERS: dict[str, logging.Logger] = {}
-
-
-class _ContextFilter(logging.Filter):
-    """Inject slice metadata into log records for structured output."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.slice_id = os.getenv("ACTIVE_SLICE_ID", "unknown")
-        self.phase = os.getenv("MOP_PHASE", "unknown")
-
-    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - interface method
-        record.slice_id = self.slice_id
-        record.phase = self.phase
-        return True
-
-
-def _create_handler(path: Path) -> logging.FileHandler:
-    ensure_directory(path.parent)
-    handler = logging.FileHandler(path, encoding="utf-8")
-    handler.setFormatter(_formatter())
-    return handler
-
-
-def _formatter() -> logging.Formatter:
-    return logging.Formatter(
-        "%(asctime)s | %(levelname)s | slice=%(slice_id)s | phase=%(phase)s | %(name)s | %(message)s"
-    )
+_default_factory = LoggerFactory()
 
 
 def get_logger(
     name: str = "release_snapshot_manager",
     log_file: Optional[Path | str] = None,
+    level: int = logging.INFO,
 ) -> logging.Logger:
-    """Return a configured logger that logs to both console and optional file."""
-    if name in _LOGGERS:
-        return _LOGGERS[name]
+    """Return a JSON-formatted logger compatible with legacy helpers."""
 
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-
-    context_filter = _ContextFilter()
-    logger.addFilter(context_filter)
-
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setFormatter(_formatter())
-    logger.addHandler(console_handler)
-
-    if log_file:
-        logger.addHandler(_create_handler(Path(log_file)))
-
-    _LOGGERS[name] = logger
-    return logger
+    return _default_factory.get_logger(name, log_file=log_file, level=level)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,99 @@
+"""Tests for the centralized configuration loader."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from modules.config.loader import ConfigLoader, ConfigValidationError, load_config
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    import yaml
+
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(json.loads(json.dumps(data)), handle)
+
+
+def test_load_config_applies_defaults_and_env(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "jira": {
+                "base_url": "https://example.atlassian.net",
+                "auth_url": "https://auth.example.com/authorize",
+                "token_url": "https://auth.example.com/token",
+                "api_scope": "read:jira",
+            },
+            "paths": {"snapshot_dir": "snapshots_custom"},
+        },
+    )
+    monkeypatch.setenv("LOGS_DIR", "custom_logs")
+
+    loader = ConfigLoader(config_path=config_path)
+    config = loader.load()
+
+    assert config["paths"]["logs_dir"] == "custom_logs"
+    assert config["paths"]["reports_dir"] == "reports"
+    assert config["jira"]["token_url"] == "https://auth.example.com/token"
+
+
+def test_load_config_reads_dotenv(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "jira": {
+                "base_url": "https://example.atlassian.net",
+                "auth_url": "https://auth.example.com/authorize",
+                "token_url": "https://auth.example.com/token",
+                "api_scope": "read:jira",
+            }
+        },
+    )
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("REPORTS_DIR=artifact_reports\n", encoding="utf-8")
+
+    loader = ConfigLoader(config_path=config_path, dotenv_path=dotenv_path)
+    config = loader.load()
+
+    assert config["paths"]["reports_dir"] == "artifact_reports"
+
+
+def test_load_config_missing_file_returns_defaults(monkeypatch, tmp_path):
+    monkeypatch.delenv("JIRA_BASE_URL", raising=False)
+    monkeypatch.delenv("JIRA_AUTH_URL", raising=False)
+    monkeypatch.delenv("JIRA_TOKEN_URL", raising=False)
+    monkeypatch.delenv("JIRA_API_SCOPE", raising=False)
+
+    defaults = {
+        "jira": {
+            "base_url": "https://example", "auth_url": "https://auth", "token_url": "https://token", "api_scope": "scope"
+        },
+        "paths": {"snapshot_dir": "snapshots", "logs_dir": "logs", "reports_dir": "reports"},
+    }
+
+    config = load_config(override_path=tmp_path / "missing.yaml", defaults=defaults)
+    assert config["paths"]["logs_dir"] == "logs"
+    assert config["jira"]["base_url"] == "https://example"
+
+
+def test_load_config_validation_error(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    _write_yaml(config_path, {"jira": {}, "paths": {}})
+
+    loader = ConfigLoader(config_path=config_path)
+    with pytest.raises(ConfigValidationError) as exc:
+        loader.load()
+
+    error_message = str(exc.value)
+    assert "Missing required setting 'jira.base_url'" in error_message
+    assert "paths.snapshot_dir" not in error_message

--- a/tests/test_logging_factory.py
+++ b/tests/test_logging_factory.py
@@ -1,0 +1,51 @@
+"""Tests for the JSON logging factory."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from modules.logging import LoggerFactory, get_logger
+
+
+def test_get_logger_emits_json(monkeypatch, capsys):
+    monkeypatch.setenv("ACTIVE_SLICE_ID", "04")
+    monkeypatch.setenv("MOP_PHASE", "build")
+    logger = get_logger("release.test")
+
+    logger.info("hello %s", "world", extra={"event": "config"})
+    captured = capsys.readouterr().out.strip()
+    data = json.loads(captured)
+
+    assert data["message"] == "hello world"
+    assert data["slice_id"] == "04"
+    assert data["phase"] == "build"
+    assert data["event"] == "config"
+
+
+def test_logger_writes_to_artifact_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path))
+    factory = LoggerFactory()
+    logger = factory.get_logger("release.file", log_file=Path("logs") / "slice.log")
+    logger.info("persist message")
+
+    log_path = tmp_path / "logs" / "slice.log"
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8").strip()
+    assert json.loads(content)["message"] == "persist message"
+
+
+def test_masking_applies_to_sensitive_values(monkeypatch, capsys):
+    monkeypatch.setenv("JIRA_SECRET", "super-secret")
+    factory = LoggerFactory()
+    logger = factory.get_logger("release.masking")
+
+    logger.warning("token=%s", "super-secret")
+    output = capsys.readouterr().out.strip()
+    assert "super-secret" not in output
+    assert "***" in output


### PR DESCRIPTION
## Summary
- add a centralized configuration loader that merges defaults, dotenv values, and environment overrides with validation
- introduce a JSON logging factory with masking support and integrate it with existing logger helpers
- cover the new configuration and logging utilities with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690cf5428548832f9a334cb5a186f844