### PR TITLE
Add OAuth token refresh handling and HTTP retry utilities

### DIFF
--- a/modules/snapshot.py
+++ b/modules/snapshot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from .utils import helpers
+from .utils.http_retry import request_with_retry
 from .utils.logger import get_logger
 from .utils.oauth import get_jira_session
 
@@ -53,7 +54,9 @@ def fetch_jql_results(fix_version: str) -> List[Dict]:
         }
         verify_path_obj = helpers.ssl_verify_path()
         verify_path = str(verify_path_obj) if verify_path_obj else True
-        response = session.get(
+        response = request_with_retry(
+            session,
+            "GET",
             f"{base_url}/rest/api/3/search",
             params=params,
             verify=verify_path,

--- a/modules/utils/http_retry.py
+++ b/modules/utils/http_retry.py
@@ -1,0 +1,120 @@
+"""HTTP retry helpers with SSL-aware exponential backoff."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from requests import Response, Session
+from requests.exceptions import ConnectionError, SSLError, Timeout
+
+from .logger import get_logger
+
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class RetryConfig:
+    """Configuration for retry behaviour."""
+
+    retries: int = 3
+    backoff_factor: float = 0.5
+    status_forcelist: Iterable[int] = (500, 502, 503, 504)
+
+
+def _should_retry_response(status_code: int, status_forcelist: Iterable[int]) -> bool:
+    return status_code in set(status_forcelist)
+
+
+def _sleep(seconds: float) -> None:
+    import time
+
+    time.sleep(seconds)
+
+
+def _backoff_delay(backoff_factor: float, attempt: int) -> float:
+    return backoff_factor * (2**attempt)
+
+
+def request_with_retry(
+    session: Session,
+    method: str,
+    url: str,
+    *,
+    retry_config: Optional[RetryConfig] = None,
+    logger: Optional[logging.Logger] = None,
+    **kwargs,
+) -> Response:
+    """Execute an HTTP request with retry/backoff for SSL and transient failures."""
+
+    cfg = retry_config or RetryConfig()
+    log = logger or LOGGER
+    attempts = 0
+    last_exception: Optional[Exception] = None
+
+    while attempts <= cfg.retries:
+        try:
+            response = session.request(method, url, **kwargs)
+        except (SSLError, ConnectionError, Timeout) as error:
+            last_exception = error
+            if attempts == cfg.retries:
+                log.error(
+                    "HTTP request failed after retries",
+                    extra={
+                        "event": "http_retry_failure",
+                        "method": method,
+                        "attempts": attempts + 1,
+                        "reason": type(error).__name__,
+                    },
+                )
+                raise
+            delay = _backoff_delay(cfg.backoff_factor, attempts)
+            log.warning(
+                "Retrying HTTP request after transient error",
+                extra={
+                    "event": "http_retry",
+                    "method": method,
+                    "attempt": attempts + 1,
+                    "delay_seconds": round(delay, 3),
+                    "reason": type(error).__name__,
+                },
+            )
+            _sleep(delay)
+            attempts += 1
+            continue
+
+        if _should_retry_response(response.status_code, cfg.status_forcelist):
+            if attempts == cfg.retries:
+                log.error(
+                    "HTTP request failed with status",
+                    extra={
+                        "event": "http_status_failure",
+                        "method": method,
+                        "status_code": response.status_code,
+                    },
+                )
+                response.raise_for_status()
+            delay = _backoff_delay(cfg.backoff_factor, attempts)
+            log.warning(
+                "Retrying HTTP request due to status code",
+                extra={
+                    "event": "http_retry",
+                    "method": method,
+                    "attempt": attempts + 1,
+                    "delay_seconds": round(delay, 3),
+                    "status_code": response.status_code,
+                },
+            )
+            _sleep(delay)
+            attempts += 1
+            continue
+
+        return response
+
+    assert last_exception is not None  # pragma: no cover - defensive
+    raise last_exception
+
+
+__all__ = ["RetryConfig", "request_with_retry"]

--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Optional
@@ -206,21 +207,87 @@ def get_jira_session() -> OAuth2Session:
         )
 
     def _token_updater(new_token: dict) -> None:
+        LOGGER.info(
+            "OAuth token updated",
+            extra={"event": "token_refresh_write", "slice_id": "07"},
+        )
         save_token(new_token, config)
 
     session.token_updater = _token_updater
     session.verify = str(verify_path) if verify_path else True
 
     # Attempt to refresh token if required
-    if session.token and session.token.get("expires_in", 0) <= 0:
-        session.refresh_token(
-            config["jira"].get("token_url"),
-            client_id=os.environ.get("JIRA_CLIENT_ID"),
-            client_secret=os.environ.get("JIRA_SECRET"),
+    if _token_expired(session.token):
+        _refresh_token(
+            session,
+            config,
             verify=str(verify_path) if verify_path else True,
         )
 
     return session
+
+
+def _token_expired(token: Optional[dict], *, leeway: int = 60) -> bool:
+    """Determine whether the token is expired or close to expiring."""
+
+    if not token:
+        return True
+
+    expires_at = token.get("expires_at")
+    if expires_at is not None:
+        try:
+            return float(expires_at) <= time.time() + leeway
+        except (TypeError, ValueError):
+            return True
+
+    expires_in = token.get("expires_in")
+    if expires_in is not None:
+        try:
+            return float(expires_in) <= leeway
+        except (TypeError, ValueError):
+            return True
+
+    return False
+
+
+def _refresh_token(
+    session: OAuth2Session,
+    config: dict,
+    *,
+    verify: bool | str,
+) -> None:
+    """Refresh the OAuth token and persist the new credentials."""
+
+    LOGGER.info(
+        "Refreshing OAuth token due to expiry",
+        extra={"event": "token_refresh", "slice_id": "07"},
+    )
+    try:
+        refreshed = session.refresh_token(
+            config["jira"].get("token_url"),
+            client_id=os.environ.get("JIRA_CLIENT_ID"),
+            client_secret=os.environ.get("JIRA_SECRET"),
+            verify=verify,
+        )
+    except Exception as error:  # noqa: BLE001 - propagate friendly context
+        LOGGER.error(
+            "OAuth token refresh failed",
+            extra={
+                "event": "token_refresh_failure",
+                "error": type(error).__name__,
+                "slice_id": "07",
+            },
+        )
+        raise
+
+    if isinstance(refreshed, dict):
+        save_token(refreshed, config)
+        session.token = refreshed
+
+    LOGGER.info(
+        "OAuth token refresh completed",
+        extra={"event": "token_refresh_success", "slice_id": "07"},
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+from requests import Response
+from requests.exceptions import ConnectionError, SSLError
+
+from modules.utils import http_retry
+
+
+def _response(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = b"{}"  # noqa: SLF001 - setting private for test convenience
+    return resp
+
+
+def test_request_with_retry_recovers_from_ssl_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts: list[int] = []
+
+    class DummySession:
+        def request(self, method: str, url: str, **kwargs):  # noqa: D401 - test stub
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise SSLError("handshake failed")
+            return _response(200)
+
+    monkeypatch.setattr(http_retry, "_sleep", lambda _: None)
+
+    response = http_retry.request_with_retry(DummySession(), "GET", "https://example.com", verify=True)
+
+    assert response.status_code == 200
+    assert len(attempts) == 2
+
+
+def test_request_with_retry_retries_on_status_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts: list[int] = []
+
+    class DummySession:
+        def request(self, method: str, url: str, **kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                return _response(503)
+            return _response(200)
+
+    monkeypatch.setattr(http_retry, "_sleep", lambda _: None)
+
+    response = http_retry.request_with_retry(DummySession(), "GET", "https://example.com", verify=True)
+
+    assert response.status_code == 200
+    assert len(attempts) == 2
+
+
+def test_request_with_retry_raises_after_exhausting_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummySession:
+        def request(self, method: str, url: str, **kwargs):
+            raise ConnectionError("network down")
+
+    monkeypatch.setattr(http_retry, "_sleep", lambda _: None)
+
+    with pytest.raises(ConnectionError):
+        http_retry.request_with_retry(
+            DummySession(),
+            "GET",
+            "https://example.com",
+            verify=True,
+            retry_config=http_retry.RetryConfig(retries=1, backoff_factor=0),
+        )

--- a/tests/test_oauth_utils.py
+++ b/tests/test_oauth_utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from modules.utils import oauth as oauth_utils
+
+
+def test_token_expired_handles_variations() -> None:
+    assert oauth_utils._token_expired(None)
+    assert oauth_utils._token_expired({"expires_at": time.time() - 10})
+    assert oauth_utils._token_expired({"expires_in": 0})
+    assert not oauth_utils._token_expired({"expires_at": time.time() + 3600})
+
+
+def test_get_jira_session_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    saved_tokens: list[Dict[str, Any]] = []
+
+    def fake_save(token: Dict[str, Any], config: Optional[dict] = None) -> Path:
+        saved_tokens.append(token)
+        return tmp_path / "token.json"
+
+    class DummySession:
+        def __init__(self, token: Optional[dict] = None, **_: Any):
+            self.token = token or {}
+            self.token_updater = None
+            self.verify: Any = True
+            self.refresh_kwargs: Dict[str, Any] | None = None
+
+        def refresh_token(self, url: str, **kwargs: Any) -> Dict[str, Any]:
+            self.refresh_kwargs = {"url": url, **kwargs}
+            new_token = {"access_token": "new", "expires_at": time.time() + 3600}
+            if self.token_updater:
+                self.token_updater(new_token)
+            self.token = new_token
+            return new_token
+
+    monkeypatch.setattr(oauth_utils, "save_token", fake_save)
+    monkeypatch.setattr(oauth_utils, "_load_token", lambda config: {"access_token": "old", "expires_at": time.time() - 5})
+    monkeypatch.setattr(oauth_utils, "_build_oauth_session", lambda config, token=None: DummySession(token))
+    monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: tmp_path / "corp.pem")
+    monkeypatch.setattr(
+        oauth_utils,
+        "load_config",
+        lambda: {
+            "jira": {
+                "token_url": "https://example.com/token",
+                "token_path": str(tmp_path / "token.json"),
+            }
+        },
+    )
+
+    monkeypatch.setenv("JIRA_CLIENT_ID", "client")
+    monkeypatch.setenv("JIRA_SECRET", "secret")
+
+    session = oauth_utils.get_jira_session()
+
+    assert session.refresh_kwargs is not None
+    assert session.refresh_kwargs["url"] == "https://example.com/token"
+    assert session.verify == str(tmp_path / "corp.pem")
+    assert saved_tokens, "token should be persisted after refresh"
+    assert session.token.get("access_token") == "new"


### PR DESCRIPTION
## Summary
- add an SSL-aware HTTP retry helper and integrate it into snapshot collection
- harden Jira OAuth session creation with proactive refresh logic and logging
- cover the new retry and refresh paths with targeted unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690d0f100050832fb4e1ba4a52cd8950