### PR TITLE
Add coverage runner and expand Guard Phase tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML>=6.0.1
 Jinja2>=3.1.2
 python-dotenv>=1.0.0
 pytest>=7.4.0
+pytest-cov>=4.1.0

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,52 @@
+"""Guard Phase helper to execute pytest with coverage artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pytest
+
+from modules.utils import helpers
+
+DEFAULT_COV_TARGETS: tuple[str, ...] = ("modules", "src")
+
+
+def build_pytest_args(
+    extra_args: Sequence[str] | None = None,
+    *,
+    targets: Iterable[str] = DEFAULT_COV_TARGETS,
+) -> tuple[list[str], Path]:
+    """Construct pytest arguments with coverage reporting to the artifact root."""
+
+    config = helpers.load_config()
+    timezone = config.get("reporting", {}).get("timezone")
+    generated_at = helpers.current_timestamp(timezone)
+    report_name = f"coverage_summary_{generated_at.strftime('%Y%m%d')}.txt"
+    report_path = helpers.artifact_path("reports", report_name)
+    helpers.ensure_directory(report_path.parent)
+
+    args: list[str] = [f"--cov={target}" for target in targets]
+    args.append(f"--cov-report=term-missing:{report_path}")
+    if extra_args:
+        args.extend(extra_args)
+    return args, report_path
+
+
+def run_pytest_with_coverage(extra_args: Sequence[str] | None = None) -> int:
+    """Execute pytest with coverage reporting and return the exit code."""
+
+    args, _ = build_pytest_args(extra_args)
+    return pytest.main(args)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run pytest with coverage artifacts")
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER, help="Arguments to forward to pytest")
+    parsed = parser.parse_args(argv)
+    return run_pytest_with_coverage(parsed.pytest_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_orchestrator_cli.py
+++ b/tests/test_orchestrator_cli.py
@@ -101,3 +101,15 @@ def test_release_notes_mask_secrets(monkeypatch, tmp_path):
     assert "super-secret" not in notes
     assert "***" in notes
     assert plan.notes_path.name == "version_tag_notes_20240101T010101Z.md"
+
+def test_analyze_requires_core_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path / "artifacts"))
+    env = {"ARTIFACT_ROOT": str(tmp_path / "artifacts")}
+    orchestrator = Orchestrator(env=env, fix_version="2.0.0")
+
+    with pytest.raises(EnvironmentError) as exc_info:
+        orchestrator.analyze()
+
+    message = str(exc_info.value)
+    assert "JIRA_CLIENT_ID" in message
+    assert "JIRA_SECRET" in message

--- a/tests/test_readiness_reporter.py
+++ b/tests/test_readiness_reporter.py
@@ -110,3 +110,49 @@ def test_generate_readiness_report_persists_artifacts(tmp_path: Path, sample_del
 
     # Clean up environment override
     del os.environ["ARTIFACT_ROOT"]
+
+def test_aggregate_readiness_merges_duplicate_entries() -> None:
+    delta = {
+        "details": {
+            "added": [
+                {
+                    "key": "ABC-10",
+                    "summary": "Introduce observability",
+                    "status": "In Progress",
+                }
+            ],
+            "changed": [
+                {
+                    "key": "ABC-20",
+                    "summary": None,
+                    "changes": {
+                        "status": {"previous": "In Progress", "current": "Blocked"},
+                        "deployment_notes": {"previous": "", "current": "Waiting"},
+                    },
+                }
+            ],
+            "unchanged": [
+                {
+                    "key": "ABC-20",
+                    "summary": "Add rate limits",
+                    "status": "Blocked",
+                }
+            ],
+        },
+        "summary": {"total_current": 2},
+    }
+
+    aggregated = reporter.aggregate_readiness(
+        delta,
+        config={
+            "project": {"done_statuses": ["Done", "Ready for Prod"]},
+            "reporting": {"timezone": "UTC"},
+        },
+    )
+
+    checklist = aggregated["checklist"]
+    assert checklist[0]["category"] == "New Issue"
+    assert checklist[1]["category"] == "Changed Issue"
+    assert "status: In Progress ➜ Blocked" in checklist[1]["notes"]
+    assert checklist[1]["summary"] == "Add rate limits"
+    assert aggregated["readiness"]["open_items"] == 2

--- a/tests/test_run_tests_script.py
+++ b/tests/test_run_tests_script.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from datetime import datetime, timezone
+
+from scripts import run_tests
+
+
+def test_build_pytest_args_generates_artifact_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setattr(run_tests.helpers, "load_config", lambda: {"reporting": {"timezone": "UTC"}})
+    fake_now = datetime(2024, 7, 15, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_tests.helpers, "current_timestamp", lambda tz=None: fake_now)
+
+    args, report_path = run_tests.build_pytest_args(["-k", "snapshot"])
+
+    expected_path = run_tests.helpers.artifact_path("reports", "coverage_summary_20240715.txt")
+    assert report_path == expected_path
+    assert expected_path.parent.exists()
+    assert "--cov=modules" in args
+    assert "--cov=src" in args
+    assert f"--cov-report=term-missing:{expected_path}" in args
+    assert args[-2:] == ["-k", "snapshot"]
+
+
+def test_run_pytest_with_coverage_invokes_pytest(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setattr(run_tests.helpers, "load_config", lambda: {"reporting": {"timezone": "UTC"}})
+    fake_now = datetime(2024, 7, 16, 9, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_tests.helpers, "current_timestamp", lambda tz=None: fake_now)
+
+    captured_args: list[list[str]] = []
+
+    def fake_pytest_main(args: list[str]) -> int:
+        captured_args.append(args)
+        return 0
+
+    monkeypatch.setattr(run_tests, "pytest", SimpleNamespace(main=fake_pytest_main))
+
+    exit_code = run_tests.run_pytest_with_coverage()
+
+    assert exit_code == 0
+    assert captured_args
+    cov_args = captured_args[0]
+    assert any(item.startswith("--cov-report=term-missing:") for item in cov_args)
+    assert any(item == "--cov=modules" for item in cov_args)
+    assert any(item == "--cov=src" for item in cov_args)

--- a/tests/test_snapshot_delta_analyzer.py
+++ b/tests/test_snapshot_delta_analyzer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from modules.snapshot_delta import analyzer
+
+
+@pytest.fixture()
+def snapshot_payloads() -> tuple[Dict[str, Any], Dict[str, Any]]:
+    current = {
+        "fixVersion": "2024.08",
+        "issues": [
+            {
+                "key": "ABC-1",
+                "summary": "New telemetry",
+                "status": "In Progress",
+                "deployment_notes": "Initial rollout",
+                "fixVersions": ["2024.08"],
+                "credential": "should-mask",
+            },
+            {
+                "key": "ABC-2",
+                "summary": "Improve logging",
+                "status": "Ready for Prod",
+                "deployment_notes": "Ready",
+                "fixVersions": ["2024.08"],
+            },
+        ],
+    }
+    previous = {
+        "fixVersion": "2024.07",
+        "issues": [
+            {
+                "key": "ABC-2",
+                "summary": "Improve logging",
+                "status": "In Review",
+                "deployment_notes": "Pending",
+                "fixVersions": ["2024.07"],
+                "token": "secret-token",
+            },
+            {
+                "key": "ABC-3",
+                "summary": "Legacy cleanup",
+                "status": "Done",
+                "deployment_notes": "Shipped",
+                "fixVersions": ["2024.07"],
+            },
+        ],
+    }
+    return current, previous
+
+
+def test_analyze_snapshots_detects_changes(snapshot_payloads: tuple[Dict[str, Any], Dict[str, Any]]) -> None:
+    current, previous = snapshot_payloads
+    result = analyzer.analyze_snapshots(
+        current,
+        previous,
+        current_path=Path("/tmp/snapshot_202408.json"),
+        previous_path=Path("/tmp/snapshot_202407.json"),
+    )
+
+    summary = result["summary"]
+    assert summary["added"] == 1
+    assert summary["removed"] == 1
+    assert summary["changed"] == 1
+    assert summary["unchanged"] == 0
+
+    changed_issue = result["details"]["changed"][0]
+    changes = changed_issue["changes"]
+    assert changes["status"]["previous"] == "In Review"
+    assert changes["status"]["current"] == "Ready for Prod"
+    assert changes["deployment_notes"]["current"] == "Ready"
+
+    added_issue = result["details"]["added"][0]
+    assert added_issue["credential"] == "MASKED"
+
+    removed_issue = result["details"]["removed"][0]
+    assert removed_issue["key"] == "ABC-3"
+    assert removed_issue["deployment_notes"] == "Shipped"
+
+    metadata = result["metadata"]
+    assert metadata["current_snapshot"] == "snapshot_202408.json"
+    assert metadata["previous_snapshot"] == "snapshot_202407.json"
+
+
+def test_format_markdown_report_includes_sections(snapshot_payloads: tuple[Dict[str, Any], Dict[str, Any]]) -> None:
+    delta = analyzer.analyze_snapshots(*snapshot_payloads)
+    markdown = analyzer.format_markdown_report(delta)
+
+    assert markdown.startswith("# Snapshot Delta")
+    assert "## Summary" in markdown
+    assert "### Field Changes" in markdown
+    assert "## Changed Issues" in markdown
+    assert "`ABC-2`" in markdown

--- a/tests/test_snapshot_module.py
+++ b/tests/test_snapshot_module.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from modules import snapshot
+
+
+class _DummyResponse:
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - status_code controls behaviour
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP error {self.status_code}")
+
+
+@pytest.fixture()
+def snapshot_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("SSL_CERT_PATH", str(tmp_path / "corp.pem"))
+
+    config: Dict[str, Any] = {
+        "paths": {"snapshot_dir": "snapshots"},
+        "jira": {
+            "base_url": "https://example.atlassian.net",
+            "jql_fields": [
+                "key",
+                "summary",
+                "status",
+                "fixVersions",
+                "customfield_12345",
+            ],
+        },
+        "project": {"deployment_notes_field": "customfield_12345"},
+        "reporting": {"timezone": "UTC"},
+    }
+    monkeypatch.setattr(snapshot.helpers, "load_config", lambda: config)
+    monkeypatch.setattr(snapshot.helpers, "timestamp_for_filename", lambda tz=None: "20240101T000000Z")
+
+    return {"ARTIFACT_ROOT": str(artifact_root)}
+
+
+def test_fetch_jql_results_persists_snapshot(snapshot_environment: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "issues": [
+            {
+                "key": "ABC-1",
+                "fields": {
+                    "summary": "Demo",
+                    "status": {"name": "In Progress"},
+                    "fixVersions": [{"name": "1.0.0"}],
+                    "customfield_12345": "Notes",
+                },
+            }
+        ]
+    }
+    monkeypatch.setattr(snapshot, "get_jira_session", lambda: object())
+    monkeypatch.setattr(snapshot, "request_with_retry", lambda *a, **k: _DummyResponse(payload))
+
+    issues = snapshot.fetch_jql_results("1.0.0")
+
+    assert len(issues) == 1
+    assert issues[0]["key"] == "ABC-1"
+
+    snapshot_path = snapshot.helpers.artifact_path("snapshots", "snapshot_20240101T000000Z.json")
+    assert snapshot_path.exists()
+    written = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert written["fixVersion"] == "1.0.0"
+    assert written["issues"][0]["deployment_notes"] == "Notes"
+
+
+def test_fetch_jql_results_uses_mock_data_on_failure(snapshot_environment: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(snapshot, "get_jira_session", lambda: object())
+    def failing_request(*_: object, **__: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(snapshot, "request_with_retry", failing_request)
+
+    issues = snapshot.fetch_jql_results("9.9.9")
+
+    assert issues  # falls back to bundled mock payload
+    assert all(issue["fixVersions"] == ["9.9.9"] for issue in issues)
+
+    snapshot_path = snapshot.helpers.artifact_path("snapshots", "snapshot_20240101T000000Z.json")
+    assert snapshot_path.exists()


### PR DESCRIPTION
## Summary
- add a pytest helper that records Guard Phase coverage summaries under the artifact root
- expand automated tests for snapshot fetching, delta analysis, readiness aggregation, and CLI environment validation
- include pytest-cov and regression tests for the new coverage runner script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690d166ad404832f9abe124f39061731