### PR TITLE
fix(oauth): harden Atlassian token exchange retries

### DIFF
--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -278,7 +278,8 @@ def authorize_jira() -> dict:
             )
             if attempts > 1:
                 LOGGER.info(
-                    "Token exchange succeeded after %s attempts", attempts,
+                    "Token exchange succeeded after %s attempts",
+                    attempts,
                     extra={
                         "event": "oauth_token_exchange_retry_success",
                         "attempts": attempts,
@@ -286,7 +287,9 @@ def authorize_jira() -> dict:
                     },
                 )
             break
-        except Exception as error:  # noqa: BLE001 - propagate context for troubleshooting
+        except (
+            Exception
+        ) as error:  # noqa: BLE001 - propagate context for troubleshooting
             response = getattr(error, "response", None)
             status_code = getattr(response, "status_code", None)
             should_retry = (

--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -168,6 +168,17 @@ def authorize_jira() -> dict:
     )
 
     session = _build_oauth_session(config)
+    redirect_uri = config["jira"].get("redirect_uri")
+    LOGGER.info(
+        "Preparing Jira authorization request",
+        extra={
+            "event": "oauth_authorize_parameters",
+            "audience": audience,
+            "redirect_uri": redirect_uri,
+            "slice_id": "07",
+        },
+    )
+
     authorization_url, _ = session.authorization_url(
         auth_url,
         audience=audience,
@@ -175,7 +186,6 @@ def authorize_jira() -> dict:
     )
 
     LOGGER.info("Starting local HTTP server to capture Jira OAuth callback")
-    redirect_uri = config["jira"].get("redirect_uri")
     parsed = urlparse(redirect_uri)
     server_address = (parsed.hostname or "localhost", int(parsed.port or 8080))
     httpd = HTTPServer(server_address, OAuthCallbackHandler)
@@ -243,41 +253,89 @@ def authorize_jira() -> dict:
 
     LOGGER.info("Authorization code received; exchanging for access token")
     verify_target = ssl_verify_path()
-    try:
-        token = session.fetch_token(
-            token_url=config["jira"].get("token_url"),
-            code=OAuthCallbackHandler.auth_code,
-            client_secret=os.environ.get("JIRA_SECRET"),
-            include_client_id=True,
-            verify=str(verify_target) if verify_target else True,
-        )
-    except Exception as error:  # noqa: BLE001 - propagate context for troubleshooting
-        response = getattr(error, "response", None)
-        if response is not None:
-            body = None
-            try:
-                body = response.text
-            except Exception:  # noqa: BLE001 - best-effort logging
-                body = "<unable to read body>"
-            LOGGER.error(
-                "OAuth token exchange failed",
-                extra={
-                    "event": "oauth_token_exchange_failure",
-                    "status_code": response.status_code,
-                    "response_body": body,
-                    "slice_id": "07",
-                },
+    token_url = config["jira"].get("token_url")
+    client_id = os.environ.get("JIRA_CLIENT_ID")
+    client_secret = os.environ.get("JIRA_SECRET")
+    if not client_id:
+        raise RuntimeError("Environment variable JIRA_CLIENT_ID is required")
+
+    client_id_prefix = client_id[:4] if len(client_id) >= 4 else client_id[0]
+    LOGGER.info("Exchanging authorization code for token at %s", token_url)
+    LOGGER.debug("Using Basic Auth with client_id=%s***", client_id_prefix)
+
+    attempts = 0
+    max_attempts = 3
+    while True:
+        attempts += 1
+        try:
+            token = session.fetch_token(
+                token_url=token_url,
+                code=OAuthCallbackHandler.auth_code,
+                auth=(client_id, client_secret),
+                include_client_id=False,
+                redirect_uri=config["jira"].get("redirect_uri"),
+                verify=str(verify_target) if verify_target else True,
             )
-        else:
-            LOGGER.error(
-                "OAuth token exchange raised unexpected error",
-                extra={
-                    "event": "oauth_token_exchange_error",
-                    "error": type(error).__name__,
-                    "slice_id": "07",
-                },
+            if attempts > 1:
+                LOGGER.info(
+                    "Token exchange succeeded after %s attempts", attempts,
+                    extra={
+                        "event": "oauth_token_exchange_retry_success",
+                        "attempts": attempts,
+                        "slice_id": "07",
+                    },
+                )
+            break
+        except Exception as error:  # noqa: BLE001 - propagate context for troubleshooting
+            response = getattr(error, "response", None)
+            status_code = getattr(response, "status_code", None)
+            should_retry = (
+                response is not None
+                and isinstance(status_code, int)
+                and 500 <= status_code < 600
+                and attempts < max_attempts
             )
-        raise
+            if should_retry:
+                LOGGER.warning(
+                    "Transient OAuth token exchange failure (status=%s); retrying %s/%s",
+                    status_code,
+                    attempts + 1,
+                    max_attempts,
+                    extra={
+                        "event": "oauth_token_exchange_retry",
+                        "status_code": status_code,
+                        "attempt": attempts,
+                        "slice_id": "07",
+                    },
+                )
+                time.sleep(min(2 ** (attempts - 1), 4))
+                continue
+
+            if response is not None:
+                body = None
+                try:
+                    body = response.text
+                except Exception:  # noqa: BLE001 - best-effort logging
+                    body = "<unable to read body>"
+                LOGGER.error(
+                    "OAuth token exchange failed",
+                    extra={
+                        "event": "oauth_token_exchange_failure",
+                        "status_code": response.status_code,
+                        "response_body": body,
+                        "slice_id": "07",
+                    },
+                )
+            else:
+                LOGGER.error(
+                    "OAuth token exchange raised unexpected error",
+                    extra={
+                        "event": "oauth_token_exchange_error",
+                        "error": type(error).__name__,
+                        "slice_id": "07",
+                    },
+                )
+            raise
 
     save_token(token, config)
     return token
@@ -294,6 +352,11 @@ def complete_authorization(auth_code: str) -> dict:
     client_secret = os.environ.get("JIRA_SECRET", "")
     token_url = config["jira"].get("token_url")
     redirect_uri = config["jira"].get("redirect_uri")
+    audience = (
+        os.environ.get("JIRA_AUDIENCE")
+        or config["jira"].get("audience")
+        or "api.atlassian.com"
+    )
 
     verify_target = ssl_verify_path()
     verify = str(verify_target) if verify_target else True
@@ -302,11 +365,11 @@ def complete_authorization(auth_code: str) -> dict:
         token_url,
         json={
             "grant_type": "authorization_code",
-            "client_id": client_id,
-            "client_secret": client_secret,
             "code": auth_code,
             "redirect_uri": redirect_uri,
+            "audience": audience,
         },
+        auth=(client_id, client_secret),
         verify=verify,
         timeout=30,
     )

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -51,7 +51,9 @@ class DummyHTTPServer:
         self.shutdown_called = True
 
 
-def test_token_exchange_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_token_exchange_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     dummy_session = DummyOAuthSession(failures=[500])
     saved_token: Dict[str, Any] = {}
 
@@ -59,7 +61,9 @@ def test_token_exchange_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     monkeypatch.setenv("JIRA_SECRET", "supersecret")
     monkeypatch.setenv("OAUTH_BROWSER_OPEN", "0")
 
-    monkeypatch.setattr(oauth_utils, "_build_oauth_session", lambda config: dummy_session)
+    monkeypatch.setattr(
+        oauth_utils, "_build_oauth_session", lambda config: dummy_session
+    )
     monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
     monkeypatch.setattr(oauth_utils, "HTTPServer", DummyHTTPServer)
     monkeypatch.setattr(oauth_utils.webbrowser, "open", lambda *_: True)
@@ -99,7 +103,9 @@ def test_token_exchange_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     assert dummy_session.fetch_kwargs is not None
     assert dummy_session.fetch_kwargs["auth"] == ("abcd1234client", "supersecret")
     assert dummy_session.fetch_kwargs["include_client_id"] is False
-    assert dummy_session.fetch_kwargs["redirect_uri"] == "http://localhost:8000/callback"
+    assert (
+        dummy_session.fetch_kwargs["redirect_uri"] == "http://localhost:8000/callback"
+    )
     assert dummy_session.fetch_kwargs["verify"] is True
     assert dummy_session.fetch_attempts == 2
 

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import requests
+
+from modules.utils import oauth as oauth_utils
+
+
+class DummyOAuthSession:
+    """Capture parameters passed to the OAuth session during testing."""
+
+    def __init__(self, failures: Optional[List[int]] = None) -> None:
+        self.fetch_kwargs: Dict[str, Any] | None = None
+        self.fetch_attempts = 0
+        self.failures = failures or []
+
+    def authorization_url(self, url: str, **kwargs: Any) -> tuple[str, str]:
+        return url, "state-token"
+
+    def fetch_token(self, *_, **kwargs: Any) -> Dict[str, Any]:
+        self.fetch_attempts += 1
+        self.fetch_kwargs = dict(kwargs)
+        if self.failures:
+            status = self.failures.pop(0)
+            response = requests.Response()
+            response.status_code = status
+            response._content = b"server error"  # type: ignore[attr-defined]
+            error = requests.HTTPError("server error")
+            error.response = response  # type: ignore[assignment]
+            raise error
+
+        return {
+            "access_token": "abc",
+            "refresh_token": "refresh-123",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+
+
+class DummyHTTPServer:
+    def __init__(self, *_: Any) -> None:
+        self.shutdown_called = False
+
+    def serve_forever(self) -> None:  # pragma: no cover - thread target
+        return
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def test_token_exchange_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dummy_session = DummyOAuthSession(failures=[500])
+    saved_token: Dict[str, Any] = {}
+
+    monkeypatch.setenv("JIRA_CLIENT_ID", "abcd1234client")
+    monkeypatch.setenv("JIRA_SECRET", "supersecret")
+    monkeypatch.setenv("OAUTH_BROWSER_OPEN", "0")
+
+    monkeypatch.setattr(oauth_utils, "_build_oauth_session", lambda config: dummy_session)
+    monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
+    monkeypatch.setattr(oauth_utils, "HTTPServer", DummyHTTPServer)
+    monkeypatch.setattr(oauth_utils.webbrowser, "open", lambda *_: True)
+
+    def fake_save(token: Dict[str, Any], config: Dict[str, Any] | None = None) -> Path:
+        saved_token.update(token)
+        return tmp_path / "token.json"
+
+    monkeypatch.setattr(oauth_utils, "save_token", fake_save)
+    monkeypatch.setattr(
+        oauth_utils,
+        "load_config",
+        lambda: {
+            "jira": {
+                "auth_url": "https://example.com/authorize",
+                "token_url": "https://example.com/token",
+                "redirect_uri": "http://localhost:8000/callback",
+                "token_path": str(tmp_path / "token.json"),
+                "api_scope": "read:me",
+            }
+        },
+    )
+
+    oauth_utils.OAuthCallbackHandler.auth_code = "auth-code-123"
+    oauth_utils.OAuthCallbackHandler.error = None
+
+    try:
+        token = oauth_utils.authorize_jira()
+    finally:
+        oauth_utils.OAuthCallbackHandler.auth_code = None
+        oauth_utils.OAuthCallbackHandler.error = None
+
+    assert token["access_token"] == "abc"
+    assert token["refresh_token"] == "refresh-123"
+    assert saved_token["access_token"] == "abc"
+    assert saved_token["refresh_token"] == "refresh-123"
+    assert dummy_session.fetch_kwargs is not None
+    assert dummy_session.fetch_kwargs["auth"] == ("abcd1234client", "supersecret")
+    assert dummy_session.fetch_kwargs["include_client_id"] is False
+    assert dummy_session.fetch_kwargs["redirect_uri"] == "http://localhost:8000/callback"
+    assert dummy_session.fetch_kwargs["verify"] is True
+    assert dummy_session.fetch_attempts == 2
+
+    basic_auth = requests.auth.HTTPBasicAuth(*dummy_session.fetch_kwargs["auth"])
+    request = requests.Request("POST", "https://example.com")
+    prepared = request.prepare()
+    basic_auth(prepared)
+    assert prepared.headers["Authorization"].startswith("Basic ")
+
+
+def test_complete_authorization_uses_basic_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: Dict[str, Any] = {}
+
+    monkeypatch.setenv("JIRA_CLIENT_ID", "abcd1234client")
+    monkeypatch.setenv("JIRA_SECRET", "supersecret")
+
+    monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
+    monkeypatch.setattr(
+        oauth_utils,
+        "load_config",
+        lambda: {
+            "jira": {
+                "token_url": "https://example.com/token",
+                "redirect_uri": "http://localhost:8000/callback",
+                "token_path": str(tmp_path / "token.json"),
+                "audience": "api.atlassian.com",
+            }
+        },
+    )
+
+    def fake_post(url: str, json: Dict[str, Any], **kwargs: Any) -> requests.Response:
+        captured["url"] = url
+        captured["json"] = json
+        captured.update(kwargs)
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b'{"access_token": "abc", "refresh_token": "refresh-456", "expires_in": 3600}'  # type: ignore[attr-defined]
+
+        def _json() -> Dict[str, Any]:
+            return {
+                "access_token": "abc",
+                "refresh_token": "refresh-456",
+                "expires_in": 3600,
+            }
+
+        response.json = _json  # type: ignore[assignment]
+        return response
+
+    saved: Dict[str, Any] = {}
+
+    def fake_save(token: Dict[str, Any], _: Dict[str, Any] | None = None) -> Path:
+        saved.update(token)
+        return tmp_path / "token.json"
+
+    monkeypatch.setattr(oauth_utils.requests, "post", fake_post)
+    monkeypatch.setattr(oauth_utils, "save_token", fake_save)
+
+    tokens = oauth_utils.complete_authorization("auth-code-xyz")
+
+    assert tokens["access_token"] == "abc"
+    assert tokens["refresh_token"] == "refresh-456"
+    assert saved["refresh_token"] == "refresh-456"
+    assert captured["auth"] == ("abcd1234client", "supersecret")
+    assert captured["json"]["audience"] == "api.atlassian.com"
+    basic_auth = requests.auth.HTTPBasicAuth(*captured["auth"])
+    request = requests.Request("POST", captured["url"])
+    prepared = request.prepare()
+    basic_auth(prepared)
+    assert prepared.headers["Authorization"].startswith("Basic ")


### PR DESCRIPTION
## Summary
- authenticate the Jira OAuth token exchange using HTTP Basic Auth credentials and log the configured audience plus redirect URI for traceability
- add diagnostics describing the token endpoint, masked client identifier, and retry outcomes while gracefully handling transient 5xx responses
- cover the authorize and manual completion flows with regression tests (tests/test_oauth_flow.py) that mock Atlassian endpoints, assert Authorization: Basic headers, and confirm persistence of access and refresh tokens

## Testing
- PYTHONPATH=. pytest tests/test_oauth_flow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e302491b8832f8893abeca9b403b1)