### PR TITLE
Fix duplicate redirect_uri argument in OAuth token exchange

### DIFF
--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -268,12 +268,17 @@ def authorize_jira() -> dict:
     while True:
         attempts += 1
         try:
+            if hasattr(session, "_client") and getattr(
+                session._client, "redirect_uri", None
+            ):
+                LOGGER.debug(
+                    "Redirect URI already set on session; omitting duplicate argument.",
+                )
             token = session.fetch_token(
                 token_url=token_url,
                 code=OAuthCallbackHandler.auth_code,
                 auth=(client_id, client_secret),
                 include_client_id=False,
-                redirect_uri=config["jira"].get("redirect_uri"),
                 verify=str(verify_target) if verify_target else True,
             )
             if attempts > 1:

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -103,9 +103,7 @@ def test_token_exchange_success(
     assert dummy_session.fetch_kwargs is not None
     assert dummy_session.fetch_kwargs["auth"] == ("abcd1234client", "supersecret")
     assert dummy_session.fetch_kwargs["include_client_id"] is False
-    assert (
-        dummy_session.fetch_kwargs["redirect_uri"] == "http://localhost:8000/callback"
-    )
+    assert "redirect_uri" not in dummy_session.fetch_kwargs
     assert dummy_session.fetch_kwargs["verify"] is True
     assert dummy_session.fetch_attempts == 2
 


### PR DESCRIPTION
## Summary
- remove the redundant redirect_uri argument when exchanging the Jira OAuth code
- log when the OAuth session already has a redirect URI configured
- update the OAuth flow test to ensure fetch_token receives the expected arguments

## Testing
- PYTHONPATH=. pytest tests/test_oauth_flow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e33fa0378832f9550da6b1eca4ee5)