### PR TITLE
fix: remove unsupported Jira offline_access scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ pip install -r requirements.txt
 
 ## 🔐 Jira OAuth 3LO Authorization
 
-The Release Intelligence tool now supports a fully automatic OAuth 3LO authorization flow.
+The Release Snapshot Manager authenticates securely with Jira Cloud using OAuth 2.0 (3-legged).
 
 ### 1️⃣ Prerequisites
-
-Ensure your `.env` file includes the following values from your Atlassian Developer Console:
+Ensure your `.env` file includes:
 
 ```env
 JIRA_CLIENT_ID=<your_client_id>
@@ -51,40 +50,52 @@ JIRA_BASE_URL=https://csaaig.atlassian.net
 
 ### 2️⃣ Run Authorization
 
-Run the following command:
-
 ```bash
 python -m modules.utils.oauth authorize
 ```
 
-This will:
+This command:
 
-- Launch your browser for Atlassian login
-- Capture the authorization code automatically from `http://localhost:8000/callback`
-- Exchange it for an access token
-- Save the token securely to `.secrets/jira_token.json`
+- Launches your browser for Atlassian login.
+- Captures the authorization code automatically from `http://localhost:8000/callback`.
+- Exchanges it for an access token.
+- Saves the token securely to `.secrets/jira_token.json`.
 
-When successful, you’ll see:
+Expected success message:
 
 ```
 ✅ Authorization complete! Token saved to .secrets/jira_token.json
 ```
 
-### 3️⃣ Token Reuse
+### 3️⃣ Token Expiration
 
-If a valid token already exists, the script will reuse it automatically and skip reauthorization:
+Atlassian Jira Cloud apps do not currently support `offline_access` for all integrations. As a result, only a short-lived `access_token` is issued (typically valid for ~1 hour).
 
-```
-✅ Existing Jira access token is still valid.
-```
-
-### 4️⃣ Manual Fallback (rare)
-
-If your environment blocks `localhost:8000` redirects, copy the code from the browser URL and run:
+When the token expires, simply re-run:
 
 ```bash
-python -m modules.utils.oauth complete <auth_code>
+python -m modules.utils.oauth authorize
 ```
+
+You’ll see:
+
+```
+⚠️ Token expired — please reauthorize with `python -m modules.utils.oauth authorize`
+```
+
+Tokens are stored automatically under `.secrets/jira_token.json` and excluded from version control.
+
+### 4️⃣ Troubleshooting
+
+- **Error: `(access_denied)` Unauthorized** – Ensure your `.env` contains the correct client ID/secret.
+- Verify your redirect URI matches exactly `http://localhost:8000/callback`.
+- Re-run authorization after saving `.env`.
+
+✅ Expected Behavior
+
+- Authorization completes successfully with `read:jira-work write:jira-work` scopes.
+- `.secrets/jira_token.json` contains an `access_token` (no `refresh_token` expected).
+- The tool gracefully requests reauthorization once expired.
 
 ## Usage
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,7 +4,7 @@
       "base_url": "https://jira.yourcompany.com",
       "auth_url": "https://auth.atlassian.com/authorize",
       "token_url": "https://auth.atlassian.com/oauth/token",
-      "api_scope": "read:jira-work write:jira-work offline_access",
+      "api_scope": "read:jira-work write:jira-work",
       "token_path": ".secrets/jira_token.json",
       "redirect_uri": "http://localhost:8080/callback",
       "jql_fields":

--- a/modules/config/loader.py
+++ b/modules/config/loader.py
@@ -34,7 +34,7 @@ DEFAULTS: Mapping[str, Any] = {
         "base_url": "",
         "auth_url": "",
         "token_url": "",
-        "api_scope": "read:jira-work offline_access",
+        "api_scope": "read:jira-work write:jira-work",
         "token_path": ".secrets/jira_token.json",
         "redirect_uri": "http://localhost:8080/callback",
         "jql_fields": ["key", "summary", "status"],

--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -114,7 +114,21 @@ def _build_oauth_session(config: dict, token: Optional[dict] = None) -> OAuth2Se
         raise RuntimeError("Environment variable JIRA_CLIENT_ID is required")
 
     redirect_uri = config["jira"].get("redirect_uri")
-    scope = config["jira"].get("api_scope")
+    configured_scope = config["jira"].get("api_scope")
+    if isinstance(configured_scope, str):
+        scope = configured_scope.split()
+    elif isinstance(configured_scope, (list, tuple)):
+        scope = list(configured_scope)
+    else:
+        scope = []
+
+    if not scope:
+        scope = ["read:jira-work", "write:jira-work"]
+
+    extra_scope = os.getenv("JIRA_SCOPES", "")
+    extra_scope_values = {s.strip() for s in extra_scope.split() if s.strip()}
+    if "offline_access" in extra_scope_values and "offline_access" not in scope:
+        scope.append("offline_access")
     token_url = config["jira"].get("token_url")
 
     secret = os.environ.get("JIRA_SECRET", "")
@@ -183,6 +197,19 @@ def token_is_valid(token: dict) -> bool:
 
     buffer = timedelta(minutes=5)
     return datetime.now(timezone.utc) < (expiry - buffer)
+
+
+def is_token_expired(token: Optional[dict]) -> bool:
+    """Return True if the token has expired."""
+
+    if not token:
+        return True
+
+    exp_time = token.get("expires_at") or 0
+    try:
+        return time.time() > float(exp_time)
+    except (TypeError, ValueError):
+        return True
 
 
 def _should_open_browser() -> bool:
@@ -464,6 +491,10 @@ def authorize_jira() -> dict:
             LOGGER.debug("Unable to derive expires_at from expires_in", exc_info=True)
 
     token_path = save_token(token, config)
+    if "refresh_token" not in token:
+        LOGGER.warning(
+            "No refresh_token received — offline_access not supported by this app."
+        )
     OAuthCallbackHandler.auth_code = None
     OAuthCallbackHandler.error = None
     LOGGER.info(
@@ -564,6 +595,17 @@ def get_jira_session() -> OAuth2Session:
 
     if not token:
         raise RuntimeError("No OAuth token found. Run the authorize_jira flow first.")
+
+    if is_token_expired(token):
+        LOGGER.info(
+            "⚠️ Token expired — please reauthorize with `python -m modules.utils.oauth authorize`"
+        )
+        authorize_jira()
+        token = _load_token(config)
+        if not token:
+            raise RuntimeError(
+                "OAuth token missing after reauthorization. Please rerun the authorize command."
+            )
 
     session = _build_oauth_session(config, token=token)
 

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -269,7 +269,9 @@ def test_authorize_jira_warns_when_refresh_token_missing(
             }
         },
     )
-    monkeypatch.setattr(oauth_utils, "_build_oauth_session", lambda config: dummy_session)
+    monkeypatch.setattr(
+        oauth_utils, "_build_oauth_session", lambda config: dummy_session
+    )
     monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
     monkeypatch.setattr(oauth_utils, "HTTPServer", DummyHTTPServer)
     monkeypatch.setattr(oauth_utils.webbrowser, "open", lambda *_: True)

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -36,7 +36,6 @@ class DummyOAuthSession:
 
         return {
             "access_token": "abc",
-            "refresh_token": "refresh-123",
             "token_type": "Bearer",
             "expires_in": 3600,
             "expires_at": time.time() + 3600,
@@ -105,9 +104,7 @@ def test_token_exchange_success(
     token = oauth_utils.authorize_jira()
 
     assert token["access_token"] == "abc"
-    assert token["refresh_token"] == "refresh-123"
     assert saved_token["access_token"] == "abc"
-    assert saved_token["refresh_token"] == "refresh-123"
     assert dummy_session.fetch_kwargs is not None
     assert dummy_session.fetch_kwargs["auth"] == ("abcd1234client", "supersecret")
     assert dummy_session.fetch_kwargs["include_client_id"] is False
@@ -177,8 +174,6 @@ def test_complete_authorization_uses_basic_auth(
     tokens = oauth_utils.complete_authorization("auth-code-xyz")
 
     assert tokens["access_token"] == "abc"
-    assert tokens["refresh_token"] == "refresh-456"
-    assert saved["refresh_token"] == "refresh-456"
     assert captured["auth"] == ("abcd1234client", "supersecret")
     assert captured["json"]["audience"] == "api.atlassian.com"
     basic_auth = requests.auth.HTTPBasicAuth(*captured["auth"])
@@ -236,10 +231,64 @@ def test_authorize_jira_persists_token_and_logs_success(
     assert token_path.exists()
     data = json.loads(token_path.read_text(encoding="utf-8"))
     assert data["access_token"] == "abc"
-    assert "refresh_token" in data
     assert any(
         "✅ Access token successfully retrieved" in message for message in info_messages
     )
+
+
+def test_authorize_jira_warns_when_refresh_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class NoRefreshSession(DummyOAuthSession):
+        def fetch_token(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
+            super().fetch_token(*args, **kwargs)
+            return {
+                "access_token": "abc",
+                "expires_in": 3600,
+                "expires_at": time.time() + 3600,
+            }
+
+    dummy_session = NoRefreshSession()
+    token_path = tmp_path / ".secrets" / "jira_token.json"
+
+    monkeypatch.setenv("JIRA_CLIENT_ID", "abcd1234client")
+    monkeypatch.setenv("JIRA_SECRET", "supersecret")
+    monkeypatch.setenv("OAUTH_BROWSER_OPEN", "0")
+
+    monkeypatch.setattr(
+        oauth_utils,
+        "load_config",
+        lambda: {
+            "jira": {
+                "auth_url": "https://example.com/authorize",
+                "token_url": "https://example.com/token",
+                "redirect_uri": "http://localhost:8000/callback",
+                "token_path": str(token_path),
+                "api_scope": "read:me",
+            }
+        },
+    )
+    monkeypatch.setattr(oauth_utils, "_build_oauth_session", lambda config: dummy_session)
+    monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
+    monkeypatch.setattr(oauth_utils, "HTTPServer", DummyHTTPServer)
+    monkeypatch.setattr(oauth_utils.webbrowser, "open", lambda *_: True)
+
+    warnings: list[str] = []
+    original_warning = oauth_utils.LOGGER.warning
+
+    def warning_spy(msg: str, *args: Any, **kwargs: Any) -> Any:
+        warnings.append(str(msg))
+        return original_warning(msg, *args, **kwargs)
+
+    monkeypatch.setattr(oauth_utils.LOGGER, "warning", warning_spy)
+
+    oauth_utils.OAuthCallbackHandler.auth_code = "auth-code-123"
+    oauth_utils.OAuthCallbackHandler.error = None
+
+    oauth_utils.authorize_jira()
+
+    assert any("No refresh_token received" in message for message in warnings)
 
 
 def test_authorize_jira_skips_when_token_valid(


### PR DESCRIPTION
## Summary
- remove the unsupported `offline_access` scope from Jira OAuth defaults and allow optional overrides
- log when refresh tokens are absent and trigger reauthorization when cached tokens expire
- refresh OAuth documentation and tests to reflect the short-lived access-token flow

## Testing
- PYTHONPATH=. pytest tests/test_oauth_flow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e572dd654832f9f34186b076ae866)