### PR TITLE
Fix duplicate scope parameter when generating Jira OAuth URL

### DIFF
--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -703,7 +703,9 @@ def _write_scope_normalization_log(base_dir: Path, payload: dict) -> None:
     try:
         directory = ensure_directory(base_dir)
         path = directory / f"oauth_scope_normalization_{_phoenix_timestamp()}.json"
-        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
     except Exception:  # noqa: BLE001 - diagnostics should not raise
         LOGGER.debug("Failed to write OAuth scope normalization log", exc_info=True)
 

--- a/modules/utils/oauth.py
+++ b/modules/utils/oauth.py
@@ -335,11 +335,26 @@ def authorize_jira() -> dict:
     )
 
     requested_scopes = _resolve_requested_scopes(config)
+    normalized_scopes = _scopes_to_oauthlib(requested_scopes) or []
     session = _build_oauth_session(config, scopes=requested_scopes)
     current_scopes = list(requested_scopes)
     offline_scope = "offline_access"
     using_fallback_scopes = False
     offline_requested = any(scope.lower() == offline_scope for scope in current_scopes)
+
+    logs_dir_setting = config.get("paths", {}).get("logs_dir")
+    logs_dir_path = (
+        resolve_path(logs_dir_setting) if logs_dir_setting else project_root() / "logs"
+    )
+
+    scope_diagnostics = {
+        "event": "oauth_scope_normalization",
+        "requested_scopes": requested_scopes,
+        "normalized_scopes": normalized_scopes,
+        "session_scope": getattr(session, "scope", None),
+    }
+    LOGGER.debug(scope_diagnostics)
+    _write_scope_normalization_log(logs_dir_path, scope_diagnostics)
 
     redirect_uri = config["jira"].get("redirect_uri")
     LOGGER.info(
@@ -356,7 +371,6 @@ def authorize_jira() -> dict:
         auth_url,
         audience=audience,
         prompt="consent",
-        scope=_scopes_to_oauthlib(requested_scopes),
     )
 
     LOGGER.info("Starting local HTTP server to capture Jira OAuth callback")
@@ -399,10 +413,6 @@ def authorize_jira() -> dict:
         "code and run:\n\npython -m modules.utils.oauth complete <auth_code>\n"
     )
 
-    logs_dir_setting = config.get("paths", {}).get("logs_dir")
-    logs_dir_path = (
-        resolve_path(logs_dir_setting) if logs_dir_setting else project_root() / "logs"
-    )
     diagnostic_recorder = OAuthDiagnosticRecorder(current_scopes, logs_dir_path)
 
     start_time = time.monotonic()
@@ -685,6 +695,17 @@ def _write_oauth_debug_snapshot(payload: dict) -> None:
         snapshot_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
     except Exception:  # noqa: BLE001 - diagnostics should not raise
         LOGGER.debug("Failed to write OAuth debug snapshot", exc_info=True)
+
+
+def _write_scope_normalization_log(base_dir: Path, payload: dict) -> None:
+    """Persist structured diagnostics for scope normalization."""
+
+    try:
+        directory = ensure_directory(base_dir)
+        path = directory / f"oauth_scope_normalization_{_phoenix_timestamp()}.json"
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    except Exception:  # noqa: BLE001 - diagnostics should not raise
+        LOGGER.debug("Failed to write OAuth scope normalization log", exc_info=True)
 
 
 def complete_authorization(auth_code: str) -> dict:

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -19,8 +19,15 @@ class DummyOAuthSession:
         self.fetch_attempts = 0
         self.failures = failures or []
         self.fetch_history: List[Dict[str, Any]] = []
+        self.authorization_kwargs: Dict[str, Any] | None = None
+        self.scope: List[str] | None = None
+
+    def with_scopes(self, scopes: Optional[List[str]]) -> "DummyOAuthSession":
+        self.scope = list(scopes) if scopes is not None else None
+        return self
 
     def authorization_url(self, url: str, **kwargs: Any) -> tuple[str, str]:
+        self.authorization_kwargs = dict(kwargs)
         return url, "state-token"
 
     def fetch_token(self, *_, **kwargs: Any) -> Dict[str, Any]:
@@ -84,7 +91,7 @@ def test_token_exchange_success(
     monkeypatch.setattr(
         oauth_utils,
         "_build_oauth_session",
-        lambda config, token=None, scopes=None: dummy_session,
+        lambda config, token=None, scopes=None: dummy_session.with_scopes(scopes),
     )
     monkeypatch.setattr(oauth_utils, "ssl_verify_path", lambda: None)
     monkeypatch.setattr(oauth_utils, "HTTPServer", DummyHTTPServer)
@@ -126,6 +133,14 @@ def test_token_exchange_success(
     assert dummy_session.fetch_kwargs["verify"] is True
     assert dummy_session.fetch_kwargs["scope"] == ["read:me"]
     assert dummy_session.fetch_attempts == 2
+    assert dummy_session.authorization_kwargs is not None
+    assert "scope" not in dummy_session.authorization_kwargs
+
+    scope_logs = list((tmp_path / "logs").glob("oauth_scope_normalization_*.json"))
+    assert scope_logs, "Expected scope normalization log to be written"
+    scope_payload = json.loads(scope_logs[0].read_text())
+    assert scope_payload["normalized_scopes"] == ["read:me"]
+    assert scope_payload["requested_scopes"] == ["read:me"]
 
     assert oauth_utils.OAuthCallbackHandler.auth_code is None
     assert oauth_utils.OAuthCallbackHandler.error is None


### PR DESCRIPTION
## Summary
- normalize requested scopes once when creating the Jira OAuth session and avoid re-supplying them to authorization_url
- add structured logging and persisted artifacts for scope normalization diagnostics
- extend OAuth flow tests to cover the regression and verify scope logs are written

## Testing
- PYTHONPATH=. pytest tests/test_oauth_flow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e688a958c832f8ce811dc23edfbff)